### PR TITLE
local-php-security-checker v2.0.4

### DIFF
--- a/.github/workflows/update-local-php-security-checker.yml
+++ b/.github/workflows/update-local-php-security-checker.yml
@@ -27,5 +27,5 @@ jobs:
             committer: 'Nikolas Evers <vintagesucks@users.noreply.github.com>'
             branch: 'local-php-security-checker-${{steps.version.outputs.prop}}'
             delete-branch: true
-            title: 'PHP ${{steps.version.outputs.prop}}'
+            title: 'local-php-security-checker ${{steps.version.outputs.prop}}'
             body: 'This pull request was [created automatically](https://github.com/vintagesucks/docker-jammy-node18-chrome-php8.1/blob/main/.github/workflows/update.yml).'

--- a/.github/workflows/update-local-php-security-checker.yml
+++ b/.github/workflows/update-local-php-security-checker.yml
@@ -28,4 +28,4 @@ jobs:
             branch: 'local-php-security-checker-${{steps.version.outputs.prop}}'
             delete-branch: true
             title: 'local-php-security-checker ${{steps.version.outputs.prop}}'
-            body: 'This pull request was [created automatically](https://github.com/vintagesucks/docker-jammy-node18-chrome-php8.1/blob/main/.github/workflows/update.yml).'
+            body: 'This pull request was [created automatically](https://github.com/vintagesucks/docker-jammy-node18-chrome-php8.1/blob/main/.github/workflows/update-local-php-security-checker.yml).'

--- a/.github/workflows/update-php.yml
+++ b/.github/workflows/update-php.yml
@@ -28,4 +28,4 @@ jobs:
             branch: 'php-${{steps.version.outputs.prop}}'
             delete-branch: true
             title: 'PHP ${{steps.version.outputs.prop}}'
-            body: 'This pull request was [created automatically](https://github.com/vintagesucks/docker-jammy-node18-chrome-php8.1/blob/main/.github/workflows/update.yml). Please check if ${{steps.version.outputs.prop}} is [available at the PPA](https://launchpad.net/~ondrej/+archive/ubuntu/php/+packages?field.name_filter=php8.1&field.status_filter=published&field.series_filter=jammy) before merging.'
+            body: 'This pull request was [created automatically](https://github.com/vintagesucks/docker-jammy-node18-chrome-php8.1/blob/main/.github/workflows/update-php.yml). Please check if ${{steps.version.outputs.prop}} is [available at the PPA](https://launchpad.net/~ondrej/+archive/ubuntu/php/+packages?field.name_filter=php8.1&field.status_filter=published&field.series_filter=jammy) before merging.'

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Docker image
 * Ubuntu 22.04
 * Node.js v18 + NPM + Yarn
 * PHP 8.1.8 + Composer
-* local-php-security-checker v2.0.3
+* local-php-security-checker v2.0.4
 * Google Chrome


### PR DESCRIPTION
This pull request was [created automatically](https://github.com/vintagesucks/docker-jammy-node18-chrome-php8.1/blob/main/.github/workflows/update-local-php-security-checker.yml).