### PR TITLE
PHP 8.1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@
 Docker image
 * Ubuntu 22.04
 * Node.js v18 + NPM + Yarn
-* PHP 8.1.10 + Composer
+* PHP 8.1.11 + Composer
 * Google Chrome


### PR DESCRIPTION
This pull request was [created automatically](https://github.com/vintagesucks/docker-jammy-node18-chrome-php8.1/blob/main/.github/workflows/update-php.yml). Please check if 8.1.11 is [available at the PPA](https://launchpad.net/~ondrej/+archive/ubuntu/php/+packages?field.name_filter=php8.1&field.status_filter=published&field.series_filter=jammy) before merging.